### PR TITLE
fix(management-ui): cumulative replacement on the pattern /management/

### DIFF
--- a/images/management-ui/Dockerfile
+++ b/images/management-ui/Dockerfile
@@ -30,7 +30,7 @@ RUN wget  https://bintray.com/artifact/download/gravitee-io/release/${GRAVITEEIO
     && rmdir graviteeio-management-ui-${GRAVITEEIO_VERSION}
 
 ENV MGMT_API_URL http://localhost/management/
-
+RUN cp /var/www/html/constants.js /var/www/html/constants.js.template
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/usr/sbin/httpd", "-DFOREGROUND"]

--- a/images/management-ui/Dockerfile-nightly
+++ b/images/management-ui/Dockerfile-nightly
@@ -30,7 +30,7 @@ RUN wget  https://bintray.com/artifact/download/gravitee-io/release/nightly/grav
     && rmdir graviteeio-management-ui-${GRAVITEEIO_VERSION}
 
 ENV MGMT_API_URL http://localhost/management/
-
+RUN cp /var/www/html/constants.js /var/www/html/constants.js.template
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/usr/sbin/httpd", "-DFOREGROUND"]

--- a/images/management-ui/entrypoint.sh
+++ b/images/management-ui/entrypoint.sh
@@ -2,7 +2,8 @@
 
 setup() {
     echo "Configure management api url to ${MGMT_API_URL}"
-    sed -i s/"'\/management\/'"/"'${MGMT_API_URL}'"/ /var/www/html/constants.js
+    cat /var/www/html/constants.js.template | \
+    sed "s#/management/#${MGMT_API_URL}#g" > /var/www/html/constants.js
 }
 
 setup


### PR DESCRIPTION
Each time the management-ui container restarts, entrypoint.sh replaces the pattern '/management/' by ${MGMT_API_URL} in constants.js. After two starts, the 'baseURL' variable  is equal to 'http://myapphttp://myapp/management/'.
Instead of change the current constants.js file, entrypoint.sh recreates a new one from the original file.