### PR TITLE
Attempt to dockerize AccessManagement based on info and docs

### DIFF
--- a/environments/demo/common-am.yml
+++ b/environments/demo/common-am.yml
@@ -1,0 +1,70 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#            http://www.apache.org/licenses/LICENSE-2.0
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#-------------------------------------------------------------------------------
+version: '2'
+
+volumes:
+  datamongo: {}
+  dataelasticsearch: {}
+
+services:
+  elasticsearch:
+    hostname: demo-elasticsearch
+    image: elasticsearch:2
+    volumes:
+      - dataelasticsearch:/usr/share/elasticsearch/data
+    ulimits:
+      nofile: 65536
+
+  mongodb:
+    hostname: demo-mongodb
+    image: mongo:3.2
+    volumes:
+      - datamongo:/data/db
+
+  gateway:
+    hostname: demo-gateway
+    image: graviteeio/gateway:latest
+    #links:
+    #  - mongodb
+    #  - elasticsearch
+    environment:
+      - GRAVITEEIO_MONGODB_HOST=mongodb
+      - GRAVITEEIO_ELASTIC_HOST=elasticsearch
+
+  managementui:
+    hostname: demo-managementui
+    image: graviteeio/management-ui:latest
+
+  managementapi:
+    hostname: demo-managementapi
+    image: graviteeio/management-api:latest
+    #links:
+    #  - mongodb
+    #  - elasticsearch
+    environment:
+      - GRAVITEEIO_MONGODB_HOST=mongodb
+      - GRAVITEEIO_ELASTIC_HOST=elasticsearch
+
+  accessmanagementgateway:
+    hostname: demo-accessmanagementgateway
+    image: graviteeio/am-gateway:latest
+    #links:
+    #  - mongodb
+    #  - elasticsearch
+    environment:
+      - GRAVITEEIO_MONGODB_HOST=mongodb
+      - GRAVITEEIO_ELASTIC_HOST=elasticsearch
+
+  accessmanagementui:
+    hostname: demo-accessmanagementui
+    image: graviteeio/am-webui:latest

--- a/environments/demo/docker-compose-local-am.yml
+++ b/environments/demo/docker-compose-local-am.yml
@@ -1,0 +1,101 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#            http://www.apache.org/licenses/LICENSE-2.0
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#-------------------------------------------------------------------------------
+version: '2'
+
+volumes:
+  local_datamongo: {}
+  local_dataelasticsearch: {}
+
+services:
+  local_elasticsearch:
+    extends:
+      file: common-am.yml
+      service: elasticsearch
+    volumes:
+      - local_dataelasticsearch:/usr/share/elasticsearch/data
+      - ./logs/elasticsearch:/var/log/elasticsearch
+
+  local_mongodb:
+    extends:
+      file: common-am.yml
+      service: mongodb
+    volumes:
+      - local_datamongo:/data/db
+      - ./logs/mongodb:/var/log/mongodb
+
+  local_gateway:
+    extends:
+      file: common-am.yml
+      service: gateway
+    links:
+      - "local_mongodb:demo-mongodb"
+      - "local_elasticsearch:demo-elasticsearch"
+    ports:
+      - "8000:8082"
+    volumes:
+      - ./logs/gateway:/etc/gravitee.io/log
+    environment:
+      - GRAVITEEIO_MONGODB_HOST=demo-mongodb
+      - GRAVITEEIO_ELASTIC_HOST=demo-elasticsearch
+
+  local_managementui:
+    extends:
+      file: common-am.yml
+      service: managementui
+    ports:
+      - "8002:80"
+    volumes:
+      - ./logs/management-ui:/var/log/httpd
+    environment:
+      - MGMT_API_URL=http:\/\/localhost:8005\/management\/
+
+  local_managementapi:
+    extends:
+      file: common-am.yml
+      service: managementapi
+    ports:
+      - "8005:8083"
+    volumes:
+      - ./logs/management-api:/home/gravitee/logs
+    links:
+      - "local_mongodb:demo-mongodb"
+      - "local_elasticsearch:demo-elasticsearch"
+    environment:
+      - GRAVITEEIO_MONGODB_HOST=demo-mongodb
+      - GRAVITEEIO_ELASTIC_HOST=demo-elasticsearch
+
+  local_accessmanagement_gateway:
+    extends:
+      file: common-am.yml
+      service: accessmanagementgateway
+    links:
+      - "local_mongodb:demo-mongodb"
+      - "local_elasticsearch:demo-elasticsearch"
+    ports:
+      - "8092:8092"
+    volumes:
+      - ./logs/am-gateway:/etc/gravitee.io/log
+    environment:
+      - GRAVITEEIO_MONGODB_HOST=demo-mongodb
+      - GRAVITEEIO_ELASTIC_HOST=demo-elasticsearch
+
+  local_accessmanagement_ui:
+    extends:
+      file: common-am.yml
+      service: accessmanagementui
+    ports:
+      - "8003:80"
+    volumes:
+      - ./logs/accessmanagement-ui:/var/log/httpd
+#    environment:
+#      - MGMT_API_URL=http:\/\/localhost:8005\/management\/

--- a/images/accessmanagement/am-gateway/Dockerfile
+++ b/images/accessmanagement/am-gateway/Dockerfile
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#            http://www.apache.org/licenses/LICENSE-2.0
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#-------------------------------------------------------------------------------
+FROM graviteeio/java:8
+MAINTAINER Gravitee Team <http://gravitee.io>
+
+ARG GRAVITEEAM_VERSION=0
+
+# Update to get support for Zip/Unzip, nc and wget
+RUN apk add --update zip unzip netcat-openbsd wget
+
+RUN wget https://download.gravitee.io/graviteeio-am/components/gravitee-am-gateway/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION}.zip --no-check-certificate -P /tmp/ \
+    && unzip /tmp/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION}.zip -d /tmp/ \
+    && mv /tmp/gravitee-am-gateway-standalone-${GRAVITEEAM_VERSION} /opt/gravitee-am-gateway \
+    && rm -rf /tmp/*
+
+ENV GRAVITEEAM_HOME /opt/gravitee-am-gateway
+WORKDIR ${GRAVITEEAM_HOME}
+
+ENV GRAVITEEIO_MONGODB_HOST localhost
+ENV GRAVITEEIO_MONGODB_PORT 27017
+ENV GRAVITEEIO_ELASTIC_HOST localhost
+ENV GRAVITEEIO_ELASTIC_PORT 9300
+
+EXPOSE 8092
+VOLUME ["/opt/gravitee-am-gateway/logs"]
+CMD ["./bin/gravitee"]

--- a/images/accessmanagement/am-gateway/Makefile
+++ b/images/accessmanagement/am-gateway/Makefile
@@ -1,0 +1,17 @@
+NAME = graviteeio/am-gateway
+VERSION = 1.3.0
+
+
+all: build
+
+build:
+	docker build -t $(NAME):$(VERSION) --rm --build-arg GRAVITEEAM_VERSION=$(VERSION) .
+
+build-nocache:
+	docker build -t $(NAME):$(VERSION) --no-cache --rm --build-arg GRAVITEEAM_VERSION=$(VERSION) .
+
+tag_latest: build
+	docker tag $(NAME):$(VERSION) $(NAME):latest
+
+run:
+		docker run -ti  -p 8092:8092 $(NAME):$(VERSION)

--- a/images/accessmanagement/am-ui/Dockerfile
+++ b/images/accessmanagement/am-ui/Dockerfile
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#            http://www.apache.org/licenses/LICENSE-2.0
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#-------------------------------------------------------------------------------
+FROM nginx:1.10.2-alpine
+MAINTAINER Gravitee Team <http://gravitee.io>
+
+ARG GRAVITEEAM_VERSION=0
+
+#COPY files/entrypoint.sh /usr/local/bin/
+#RUN chmod u+x /usr/local/bin/entrypoint.sh
+
+# Update to get support for Zip/Unzip, Bash
+RUN apk --update add zip unzip bash wget
+
+ENV WWW_TARGET /var/www/html/
+COPY files/mysite.template /etc/nginx/conf.d/default.conf
+
+RUN wget https://download.gravitee.io/graviteeio-am/components/gravitee-am-webui/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip --no-check-certificate -P /tmp/ \
+    && unzip /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}.zip -d /tmp/ \
+    && mkdir -p ${WWW_TARGET} \
+    && mv /tmp/gravitee-am-webui-${GRAVITEEAM_VERSION}/* ${WWW_TARGET} \
+    && rm -rf /tmp/*
+
+#ENV MGMT_API_URL http://localhost:8092/management/
+
+#RUN cp /var/www/html/constants.json /var/www/html/constants.json.template
+
+# forward request and error logs to docker log collector
+#RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+#	&& ln -sf /dev/stderr /var/log/nginx/error.log
+
+EXPOSE 80
+#ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/images/accessmanagement/am-ui/Makefile
+++ b/images/accessmanagement/am-ui/Makefile
@@ -1,0 +1,18 @@
+NAME = graviteeio/am-webui
+VERSION = 1.3.0
+
+.PHONY: all build build-nocache test tag_latest release
+
+all: build
+
+build:
+	docker build -t $(NAME):$(VERSION) --rm --build-arg GRAVITEEAM_VERSION=$(VERSION) .
+
+build-nocache:
+	docker build -t $(NAME):$(VERSION) --no-cache --rm --build-arg GRAVITEEAM_VERSION=$(VERSION) .
+
+tag_latest: build
+	docker tag $(NAME):$(VERSION) $(NAME):latest
+
+run:
+		docker run -ti  -p 4200:80 $(NAME):$(VERSION)

--- a/images/accessmanagement/am-ui/files/mysite.template
+++ b/images/accessmanagement/am-ui/files/mysite.template
@@ -1,0 +1,12 @@
+
+server {
+    listen 80;
+    server_name _;
+    root /var/www/html;
+    index index.html ;
+    charset utf-8;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Hi,
Based on yesterday discussion #702 I started  building docker images for Gravitee AccessManagement.
Launching the docker-compose docker-compose-local-am.yml, I don't see no specific error in the logs, and the access management ui is acessible on http://localhost:8092/, but no way to connect and to interact otherwise.
Having little knowledge of the application itself, and no more time to investigate, I let this as a start.
Thanks for the stuff, and please update the docs when possible !
Regards