### PR TITLE
Replace the default rest api base url correctly

### DIFF
--- a/images/management-ui/files/entrypoint.sh
+++ b/images/management-ui/files/entrypoint.sh
@@ -3,7 +3,7 @@
 setup() {
     echo "Configure management api url to ${MGMT_API_URL}"
     cat /var/www/html/constants.json.template | \
-    sed "s#/management/#${MGMT_API_URL}#g" > /var/www/html/constants.json
+    sed "s#http://localhost:8083/management/#${MGMT_API_URL}#g" > /var/www/html/constants.json
 }
 
 setup


### PR DESCRIPTION
Closes gravitee-io/issues#792