### PR TITLE
Update Dockerfile-nightly

### DIFF
--- a/images/management-ui/Dockerfile-nightly
+++ b/images/management-ui/Dockerfile-nightly
@@ -16,8 +16,17 @@ MAINTAINER Gravitee Team <http://gravitee.io>
 ARG GRAVITEEIO_VERSION=0
 
 COPY files/*.sh /usr/local/bin/
-RUN chmod u+x /usr/local/bin/*.sh
+RUN chmod u+x /usr/local/bin/*.sh 
 
+# chmod to be compliant with Opensifht
+# Openshift v3 uses a randomly User inside the container.
+# This makes the user and group setting in the most Dockerfile and app not 
+# very helpfully.
+
+RUN chmod -R 755 /var/www/ /var/log/nginx /var/cache/nginx/ \
+    && chmod 644 /etc/nginx/*
+
+     
 # Update to get support for Zip/Unzip, Bash
 RUN apk --update add zip unzip bash wget
 


### PR DESCRIPTION
# chmod to be compliant with Opensifht
# Openshift v3 uses a randomly User inside the container.
# This makes the user and group setting in the most Dockerfile and app not 
# very helpfully.