### PR TITLE
Add timezone management with Alpine package tzdata

### DIFF
--- a/images/java/Dockerfile
+++ b/images/java/Dockerfile
@@ -13,6 +13,8 @@
 FROM openjdk:8-jre-alpine
 MAINTAINER Gravitee Team <http://gravitee.io>
 
+RUN apk add tzdata
+
 RUN mkdir /opt
 
 # Define default command.


### PR DESCRIPTION
Hi,

Timestamps in Docker container are incorrect due to missing timezone info. This can be corrected with package tzdata, and the TZ environment variable.

After the build of graviteeio/java:8, you can test with :
`docker run -ti --rm graviteeio/java:8 date`
vs.
`docker run -ti --rm -e "TZ=Europe/Paris" graviteeio/java:8 date`
