### PR TITLE
fix(traefik): Fix traefik version to 1.7...

### DIFF
--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 
 services:
   traefik:
-    image: traefik
+    image: traefik:v1.7
     command: --api --docker
     ports:
       # only expose https to outside world
@@ -30,7 +30,7 @@ services:
     networks:
       frontend:
         aliases:
-          - am.gravitee.io      
+          - am.gravitee.io
 
   mongodb:
     image: mongo:3.4
@@ -64,7 +64,7 @@ services:
       - storage
 
   apim_gateway:
-    image: graviteeio/gateway:latest
+    image: graviteeio/gateway:1.30.1
     restart: always
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
@@ -82,19 +82,23 @@ services:
       - frontend
 
   apim_portal:
-    image: graviteeio/management-ui:latest
+    image: graviteeio/management-ui:1.30.1
     restart: always
     environment:
       - MGMT_API_URL=https:\/\/apim.gravitee.io\/management\/
     labels:
-      - "traefik.frontend.rule=Host:apim.gravitee.io;PathPrefixStrip:/portal"
+      - "traefik.frontend.redirect.regex=^https://apim.gravitee.io/portal$$"
+      - "traefik.frontend.redirect.replacement=https://apim.gravitee.io/portal/"
+      - "traefik.frontend.redirect.permanent=true"
+      # Warn: do not use PathPrefixStrip cause it not works well with redirect (https://github.com/containous/traefik/issues/1957#issuecomment-359369625)
+      - "traefik.frontend.rule=Host:apim.gravitee.io;PathPrefix:/portal;ReplacePathRegex: ^/portal/(.*) /$$1"
     depends_on:
       - apim_management
     networks:
       - frontend
 
   apim_management:
-    image: graviteeio/management-api:latest
+    image: graviteeio/management-api:1.30.1
     restart: always
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
@@ -153,8 +157,8 @@ services:
     image: graviteeio/am-management-ui:2
     restart: always
     environment:
-      - MGMT_API_URL=https:\/\/am.gravitee.io\/
-      - MGMT_UI_URL=https:\/\/am.gravitee.io\/
+      - MGMT_API_URL=https:\/\/am.gravitee.io
+      - MGMT_UI_URL=https:\/\/am.gravitee.io
     labels:
       - "traefik.backend=graviteeio-am-managementui"
       - "traefik.frontend.rule=Host:am.gravitee.io"


### PR DESCRIPTION
...switch apim version from latest to 1.30.1, handle redirect from https://apim.gravitee.io/portal to https://apim.gravitee.io/portal/ (with '/') to avoid 404 from portal UI.