### PR TITLE
feat(docker-compose-nightly): add dedicated docker-compose-nightly

### DIFF
--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     ports:
       # only expose https to outside world
       - "443:443"   # SSL
-      - "8080:8080" # Traefik dashboard
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "$PWD/traefik/config/traefik.toml:/etc/traefik/traefik.toml"
@@ -33,7 +32,7 @@ services:
           - am.gravitee.io
 
   mongodb:
-    image: mongo:3.4
+    image: mongo:${MONGODB_VERSION:-3.4}
     restart: always
     environment:
       - MONGO_INITDB_DATABASE=gravitee
@@ -46,7 +45,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-6.3.1}
     restart: always
     environment:
       - http.host=0.0.0.0
@@ -64,7 +63,7 @@ services:
       - storage
 
   apim_gateway:
-    image: graviteeio/gateway:latest
+    image: graviteeio/gateway:${APIM_VERSION:-latest}
     restart: always
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
@@ -83,7 +82,7 @@ services:
       - frontend
 
   apim_portal:
-    image: graviteeio/management-ui:latest
+    image: graviteeio/management-ui:${APIM_VERSION:-latest}
     restart: always
     environment:
       - MGMT_API_URL=https:\/\/apim.gravitee.io\/management\/
@@ -100,7 +99,7 @@ services:
       - frontend
 
   apim_management:
-    image: graviteeio/management-api:latest
+    image: graviteeio/management-api:${APIM_VERSION:-latest}
     restart: always
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
@@ -122,7 +121,7 @@ services:
       - frontend
 
   am_gateway:
-    image: graviteeio/am-gateway:latest
+    image: graviteeio/am-gateway:${AM_VERSION:-latest}
     restart: always
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee-am?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
@@ -139,7 +138,7 @@ services:
       - frontend
 
   am_management:
-    image: graviteeio/am-management-api:latest
+    image: graviteeio/am-management-api:${AM_VERSION:-latest}
     restart: always
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee-am?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
@@ -159,10 +158,10 @@ services:
       - frontend
 
   am_webui:
-    image: graviteeio/am-management-ui:latest
+    image: graviteeio/am-management-ui:${AM_VERSION:-latest}
     restart: always
     environment:
-      - MGMT_API_URL=https:\/\/am.gravitee.io
+      - MGMT_API_URL=https:\/\/am.gravitee.io${AM_MGT_API_BASE:-}
       - MGMT_UI_URL=https:\/\/am.gravitee.io
     labels:
       - "traefik.backend=graviteeio-am-managementui"

--- a/platform/launch.sh
+++ b/platform/launch.sh
@@ -16,8 +16,8 @@
 #
 
 readonly WORKDIR="$HOME/graviteeio-api-platform"
-readonly DIRNAME=`dirname $0`
-readonly PROGNAME=`basename $0`
+readonly DIRNAME=$(dirname $0)
+readonly PROGNAME=$(basename $0)
 readonly color_title='\033[32m'
 readonly color_text='\033[1;36m'
 
@@ -26,6 +26,55 @@ declare cygwin=false
 declare darwin=false
 declare linux=false
 declare dc_exec="docker-compose up"
+declare apim_version="latest"
+declare am_version="latest"
+declare am_mgt_api_base=""
+
+optspec=":h-:"
+while getopts "$optspec" optchar; do
+    case "${optchar}" in
+    -)
+        case "${OPTARG}" in
+        am_version=*)
+            am_version=${OPTARG#*=}
+            ;;
+        apim_version=*)
+            apim_version=${OPTARG#*=}
+            ;;
+        version=*)
+            am_version=${OPTARG#*=}
+            apim_version=${OPTARG#*=}
+            ;;
+        *)
+            if [ "$OPTERR" = 1 ] && [ "${optspec:0:1}" != ":" ]; then
+                echo "Unknown option --${OPTARG}" >&2
+            fi
+            ;;
+        esac
+        ;;
+    h)
+        echo "usage: $0 [-v] [--version[=]<value>]" >&2
+        echo "usage: $0 [-v] [--am_version[=]<value>] [--apim_version[=]<value>]" >&2
+
+        exit 2
+        ;;
+    *)
+        if [ "$OPTERR" != 1 ] || [ "${optspec:0:1}" = ":" ]; then
+            echo "Non-option argument: '-${OPTARG}'" >&2
+        fi
+        ;;
+    esac
+done
+
+echo "Running Gravitee platform"
+echo "APIM version: ${apim_version}"
+echo "AM version: ${am_version}"
+
+if [[ $am_version == nightly ]] || [[ $am_version == 3.* ]]; then
+    am_mgt_api_base="\/"
+fi
+
+dc_exec="APIM_VERSION=${apim_version} AM_VERSION=${am_version} AM_MGT_API_BASE=${am_mgt_api_base} ${dc_exec}"
 
 welcome() {
     echo
@@ -35,7 +84,7 @@ welcome() {
     echo -e " ${color_title} | | |_ |  __/ _  \ \ / / | __/ _ \/ _ \ | |/ _ \                           \033[0m"
     echo -e " ${color_title} | |__| | | | (_| |\ V /| | ||  __/  __/_| | (_) |                          \033[0m"
     echo -e " ${color_title}  \_____|_|  \__,_| \_/ |_|\__\___|\___(_)_|\___/                           \033[0m"
-    echo -e " ${color_title}                         \033[0m${color_text}http://gravitee.io\033[0m"     
+    echo -e " ${color_title}                         \033[0m${color_text}http://gravitee.io\033[0m"
     echo -e " ${color_title}                                                                            \033[0m"
     echo -e " ${color_title}                 _____ _____    _____  _       _    __                      \033[0m"
     echo -e " ${color_title}           /\   |  __ \_   _|  |  __ \| |     | |  / _|                     \033[0m"
@@ -51,30 +100,31 @@ welcome() {
 init_env() {
     local dockergrp
     # define env
-    case "`uname`" in
-        CYGWIN*)
-            cygwin=true
-            ;;
+    case "$(uname)" in
+    CYGWIN*)
+        cygwin=true
+        ;;
 
-        Darwin*)
-            darwin=true
-            ;;
+    Darwin*)
+        darwin=true
+        ;;
 
-        Linux)
-            linux=true
-            ;;
+    Linux)
+        linux=true
+        ;;
     esac
 
     # test if docker must be run with sudo
     dockergrp=$(groups | grep -c docker)
     if [[ $darwin == false && $dockergrp == 0 ]]; then
-        dc_exec="sudo $dc_exec";
+        dc_exec="sudo $dc_exec"
     fi
 }
 
 main() {
     welcome
     init_env
+
     if [[ $? != 0 ]]; then
         exit 1
     fi
@@ -83,15 +133,14 @@ main() {
     pushd $WORKDIR > /dev/null
         echo "Download required files ..."
         mkdir -p traefik/certs ; mkdir -p traefik/config ; mkdir -p mongo/docker-entrypoint-initdb.d
-        curl -L https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/docker-compose.yml -o "docker-compose.yml"
-        cd mongo/docker-entrypoint-initdb.d && { curl -L https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/mongo/docker-entrypoint-initdb.d/create-index.js -o "create-index.js" ; cd -; }
-        cd traefik/certs && { curl -L https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/traefik/certs/gio-selfsigned.crt -o "gio-selfsigned.crt" ; cd -; }
-        cd traefik/certs && { curl -L https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/traefik/certs/gio-selfsigned.key -o "gio-selfsigned.key" ; cd -; }
-        cd traefik/certs && { curl -L https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/traefik/certs/gio.pem -o "gio.pem" ; cd -; }
-        cd traefik/config && { curl -L https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/traefik/config/traefik.toml -o "traefik.toml" ; cd -; }
+        curl -Lf https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/docker-compose.yml -o "docker-compose.yml"
+        cd mongo/docker-entrypoint-initdb.d && { curl -Lf https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/mongo/docker-entrypoint-initdb.d/create-index.js -o "create-index.js" ; cd -; }
+        cd traefik/certs && { curl -Lf https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/traefik/certs/gio-selfsigned.crt -o "gio-selfsigned.crt" ; cd -; }
+        cd traefik/certs && { curl -Lf https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/traefik/certs/gio-selfsigned.key -o "gio-selfsigned.key" ; cd -; }
+        cd traefik/config && { curl -Lf https://raw.githubusercontent.com/gravitee-io/gravitee-docker/master/platform/traefik/config/traefik.toml -o "traefik.toml" ; cd -; }
         echo
         echo "Launch Gravitee.io API Platform..."
-        $dc_exec
+        eval ${dc_exec}
     popd > /dev/null
 }
 


### PR DESCRIPTION
Allows to keep a single repository to manage docker image builds whatever the version of Gravitee APIM to build and also allows to manage docker-compose files to run either latest version either nightly version (aka v3).

launch.sh can be used with '--nightly' to run the nightly build of the Gravitee platform.