### PR TITLE
fix: EE docker image jdk upgrade openjdk11:jre-11.0.10_9-alpine

### DIFF
--- a/enterprise/am/3.x/gateway/Dockerfile
+++ b/enterprise/am/3.x/gateway/Dockerfile
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_AM_VERSION=0

--- a/enterprise/am/3.x/management-api/Dockerfile
+++ b/enterprise/am/3.x/management-api/Dockerfile
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_AM_VERSION=0

--- a/enterprise/apim/3.x/gateway/Dockerfile
+++ b/enterprise/apim/3.x/gateway/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/enterprise/apim/3.x/management-api/Dockerfile
+++ b/enterprise/apim/3.x/management-api/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/images/gateway/Dockerfile-nightly
+++ b/images/gateway/Dockerfile-nightly
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine
 MAINTAINER Gravitee Team <http://gravitee.io>
 
 ARG GRAVITEEIO_VERSION=0

--- a/images/management-api/Dockerfile-nightly
+++ b/images/management-api/Dockerfile-nightly
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM adoptopenjdk/openjdk11:jre-11.0.7_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine
 MAINTAINER Gravitee Team <http://gravitee.io>
 
 ARG GRAVITEEIO_VERSION=0


### PR DESCRIPTION
Closes gravitee-io/issues#5472