### PR TITLE
Add a fake smtp server to APIM Nighty env

### DIFF
--- a/environments/demo/docker-compose-traefik-nightly.yml
+++ b/environments/demo/docker-compose-traefik-nightly.yml
@@ -83,6 +83,9 @@ services:
       - gravitee_email_enabled=true
       - gravitee_email_host=fakesmtp
       - gravitee_email_port=1025
+      - gravitee_management_url=https://nightly.gravitee.io
+      - gravitee_portal_url=https://v3.nightly.gravitee.io
+      - gravitee_portal_entrypoint=https://nightly.gravitee.io/gateway
   nightly_portalui:
     image: graviteeio/portal-ui:nightly
     network_mode: "bridge"

--- a/environments/demo/docker-compose-traefik-nightly.yml
+++ b/environments/demo/docker-compose-traefik-nightly.yml
@@ -74,10 +74,15 @@ services:
     links:
       - nightly_mongodb
       - nightly_elasticsearch
+      - fakesmtp
+    depends_on:
+      - fakesmtp
     environment:
       - gravitee_management_mongodb_uri=mongodb://demo-mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_analytics_elasticsearch_endpoints_0=http://demo-elasticsearch:9200
-
+      - gravitee_email_enabled=true
+      - gravitee_email_host=fakesmtp
+      - gravitee_email_port=1025
   nightly_portalui:
     image: graviteeio/portal-ui:nightly
     network_mode: "bridge"
@@ -89,3 +94,13 @@ services:
       - "traefik.frontend.rule=Host:v3.nightly.gravitee.io"
     environment:
       - PORTAL_API_URL=https:\/\/nightly.gravitee.io\/api\/portal\/environments\/DEFAULT
+
+  fakesmtp:
+    image: reachfive/fake-smtp-server:0.8.1
+    network_mode: "bridge"
+    labels:
+      - "traefik.backend=nightly-graviteeio-fakesmtp-ui"
+      - "traefik.frontend.rule=Host:email.nightly.gravitee.io"
+      - "traefik.port=1080"
+    ports:
+      - "1025:1025"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5691

**Description**

I added a fake SMTP server to APIM Nighty env, as soon as this PR will be merged any nightly deployment of APIM will also redeploy a super simple fake SMTP server.

⚠️ Important notes:
 - Any email sent by APIM Nightly will be available on `https://email.nightly.gravitee.io`, whatever the recipient/cc etc.
 - The mailbox will be cleaned each time the nightly env is deployed (so at least every night)
 - All the emails are PUBLICLY available, meaning anyone with access to `https://email.nightly.gravitee.io` can see them, so be kind in your email/template and do not share any internal info.


**How to tests**

 - Check CI run of `Gravitee.io Test` triggered after a deployment with the updated docker-compose file: https://ci2.gravitee.io/job/Gravitee.io%20Test/1832/
 - Check `https://email.nightly.gravitee.io` is working fine, by creating an account for instance 