### PR TITLE
fix: prevent changelog dockerfile to use latest groovy docker image w…

### DIFF
--- a/images/changelog/Dockerfile
+++ b/images/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM groovy
+FROM groovy:jdk11
 MAINTAINER GraviteeSource Team <http://graviteesource.com>
 
 USER root


### PR DESCRIPTION
…ith jdk17

Use groovy 'jdk11' tag, cause latest groovy docker image uses jdk17, which leads to some incompatibilities.