### PR TITLE
feat: add nginx base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,27 @@ jobs:
           command: |
             echo "Digest is: $(</tmp/digest.txt)"
 
+  build-and-push-nginx:
+    executor: docker/docker
+    steps:
+      - setup_remote_docker
+      - checkout
+      - docker/check
+      - docker/build:
+          docker-context: images/nginx
+          image: graviteeio/nginx
+          path: images/nginx
+          tag: "1.12"
+      - docker/push:
+          digest-path: /tmp/digest.txt
+          image: graviteeio/nginx
+          tag: "1.12"
+      - run:
+          command: |
+            echo "Digest Nginx image is: $(</tmp/digest.txt)"
+
 workflows:
   run_every_week:
     jobs:
       - build-and-push-java
+      - build-and-push-nginx

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -1,0 +1,38 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2015-2022 The Gravitee team (http://gravitee.io)
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#            http://www.apache.org/licenses/LICENSE-2.0
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#-------------------------------------------------------------------------------
+FROM nginx:1.21-alpine
+LABEL maintainer="contact@graviteesource.com"
+
+ENV CONFD_VERSION="0.16.0"
+ENV CONFD_URL="https://github.com/kelseyhightower/confd/releases/download"
+
+ENV WWW_TARGET /usr/share/nginx/html
+
+RUN apk update \
+  && apk add --update --no-cache wget \
+  && wget -T 5 ${CONFD_URL}/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 -O /bin/confd \
+  && chmod +x /bin/confd \
+  && ln -sf /dev/stdout /var/log/nginx/access.log \
+  && ln -sf /dev/stderr /var/log/nginx/error.log \
+  && sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
+  && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
+  && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \
+  && chown -R 101:0 /usr/share/nginx /var/log/nginx /var/cache/nginx /etc/nginx /var/run \
+  && chmod -R g+w /var/cache/nginx \
+  && chmod -R g+w /etc/nginx \
+  && apk del wget
+
+ADD conf.d /etc/confd/conf.d
+COPY run.sh /run.sh
+
+CMD ["sh", "/run.sh"]

--- a/images/nginx/conf.d/constants.json.toml
+++ b/images/nginx/conf.d/constants.json.toml
@@ -1,0 +1,3 @@
+[template]
+src = "constants.json.tmpl"
+dest = "/usr/share/nginx/html/constants.json"

--- a/images/nginx/conf.d/default.conf.toml
+++ b/images/nginx/conf.d/default.conf.toml
@@ -1,0 +1,3 @@
+[template]
+src = "default.conf.tmpl"
+dest = "/etc/nginx/conf.d/default.conf"

--- a/images/nginx/run.sh
+++ b/images/nginx/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Copyright (C) 2015-2022 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# generate configs
+/bin/confd -onetime -backend env
+
+# start nginx foreground
+exec /usr/sbin/nginx -g 'daemon off;'


### PR DESCRIPTION
**Description**

Fetch and configure confd.
The image is embedding 2 confd toml file:
- default.conf.toml: to configure nginx
- constants.json.toml: to configure ManagementUI constants.json file

Example of usage:

```
FROM graviteeio/nginx:1.21 as management-ui
LABEL maintainer="contact@graviteesource.com"

COPY --from=ui-builder /tmp/gravitee-cockpit-ui $WWW_TARGET
COPY --from=ui-builder /tmp/config/templates /etc/confd/templates
```

**Additional context**

Tested it on Cockpit: https://github.com/gravitee-io/gravitee-cockpit/pull/2292/commits/d8b4b12ddf72e749de6fdcfe6a79b0969dcfdf3d