### PR TITLE
cicd: adding devops as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 *                       @gravitee-io/archi
 /enterprise/apim/       @gravitee-io/apim
 /enterprise/am/         @gravitee-io/am
+*                       @gravitee-io/devops


### PR DESCRIPTION

**Description**

this PR is created in order to add devops team as codeowners
