### PR TITLE
ci: adding devops as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Default
 *                       @gravitee-io/archi
+*                       @gravitee-io/devops
 /enterprise/apim/       @gravitee-io/apim
 /enterprise/am/         @gravitee-io/am


### PR DESCRIPTION
This PR is created in order to add the devops team as codeowners