### PR TITLE
chore: upgraded nginx 1.21 to 1.23

### DIFF
--- a/images/management-ui/Dockerfile
+++ b/images/management-ui/Dockerfile
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/images/management-ui/Dockerfile-nightly
+++ b/images/management-ui/Dockerfile-nightly
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ENV CONFD_VERSION="0.16.0"

--- a/images/portal-ui/Dockerfile-nightly
+++ b/images/portal-ui/Dockerfile-nightly
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0


### PR DESCRIPTION
**Description**

nginx 1.23 has been released, which includes bug fixes and security patches found in 1.21 and 1.22. It also includes patches to alpine as nginx 1.23 uses 3.16 of alpine and not 3.15.
