### PR TITLE
fix(nginx): security fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: |
             docker context create tls-env
             docker buildx create tls-env --use
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -t graviteeio/nginx:1.23 -f images/nginx/Dockerfile images/nginx/
+            docker buildx build --push --platform=linux/arm64,linux/amd64 -t graviteeio/nginx:1.23.3 -f images/nginx/Dockerfile images/nginx/
 
   build-and-push-git-http-server:
     executor: docker/docker

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM nginx:1.23.3-alpine
+FROM nginx:1.23.3
 LABEL maintainer="contact@graviteesource.com"
 
 ENV CONFD_VERSION="v0.19.1"


### PR DESCRIPTION
Use nginx:1.23.3 instead of 1.23.3-alpine to fix some CVE
