### PR TITLE
chore: PR branches override master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,9 @@ jobs:
 
 workflows:
   run_every_week:
+    when:
+      and:
+        - equal: [ master, << pipeline.git.branch >> ]
     jobs:
       - build-and-push-java:
           context: cicd-orchestrator


### PR DESCRIPTION
Avoid override docker images by other branch than master