### PR TITLE
feat: add nginx without confd image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,20 @@ jobs:
             docker buildx create tls-env --use
             docker buildx build --push --platform=linux/arm64,linux/amd64 -t graviteeio/java:17 -f images/java/Dockerfile images/java/
 
+  build-and-push-nginx-noconfd:
+    executor: docker/docker
+    parameters:
+      version:
+        type: string
+    steps:
+      - checkout
+      - prepare-docker-context
+      - run:
+          command: |
+            docker context create tls-env
+            docker buildx create tls-env --use
+            docker buildx build --push --platform=linux/arm64,linux/amd64 --build-arg NGINX_VERSION=<< parameters.version >> -t graviteeio/nginx-noconfd:<< parameters.version >> -f images/nginx-noconfd/Dockerfile images/nginx-noconfd/
+
   build-and-push-nginx:
     executor: docker/docker
     parameters:
@@ -62,7 +76,7 @@ jobs:
           command: |
             docker context create tls-env
             docker buildx create tls-env --use
-            docker buildx build --push --platform=linux/arm64,linux/amd64 --build-arg NGINX_VERSION=<< parameters.version >> -t graviteeio/nginx:<< parameters.version >> -f images/nginx/Dockerfile images/nginx/
+            docker buildx build --push --platform=linux/arm64,linux/amd64 --build-arg NGINX_VERSION=<< parameters.version >> -t graviteeio/nginx:<< parameters.version >> -f images/nginx/Dockerfile images/nginx/        
 
   build-and-push-git-http-server:
     executor: docker/docker
@@ -133,6 +147,10 @@ workflows:
           version: "1.24"
       - build-and-push-nginx:
           name: build nginx 1.25
+          context: cicd-orchestrator
+          version: "1.25"
+      - build-and-push-nginx-noconfd:
+          name: build nginx-noconfd 1.25
           context: cicd-orchestrator
           version: "1.25"
       - add-docker-images-in-snyk:

--- a/images/nginx-noconfd/Dockerfile
+++ b/images/nginx-noconfd/Dockerfile
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2015-2022 The Gravitee team (http://gravitee.io)
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#            http://www.apache.org/licenses/LICENSE-2.0
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#-------------------------------------------------------------------------------
+ARG  NGINX_VERSION=1.25
+FROM nginx:${NGINX_VERSION}-alpine
+LABEL maintainer="contact@graviteesource.com"
+
+ENV WWW_TARGET /usr/share/nginx/html
+ENV HTTP_PORT 8080
+ENV HTTPS_PORT 8443
+ENV SERVER_NAME _
+ENV DOLLAR $
+
+RUN apk -U upgrade \
+  && apk add --update --no-cache wget curl \
+  && rm -rf /var/cache/apk/*
+
+RUN ln -sf /dev/stdout /var/log/nginx/access.log; \
+  ln -sf /dev/stderr /var/log/nginx/error.log; \
+  sed -i '/user  nginx;/d' /etc/nginx/nginx.conf; \
+  sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf; \
+  sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf; \
+  chown -R 101:0 /usr/share/nginx /var/log/nginx /var/cache/nginx /etc/nginx /var/run; \
+  chmod -R g+w /var/cache/nginx; \
+  chmod -R g+w /etc/nginx; \
+  apk del wget;
+
+COPY run.sh /run.sh
+
+CMD ["sh", "/run.sh"]

--- a/images/nginx-noconfd/run.sh
+++ b/images/nginx-noconfd/run.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Copyright (C) 2015-2022 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# generate configs
+if [ -f "/usr/share/nginx/html/constants.json" ]; then
+    envsubst < /usr/share/nginx/html/constants.json > /usr/share/nginx/html/constants.json.tmp
+    mv /usr/share/nginx/html/constants.json.tmp /usr/share/nginx/html/constants.json
+fi
+
+if [ -f "/usr/share/nginx/html/assets/config.json" ]; then
+    envsubst < /usr/share/nginx/html/assets/config.json > /usr/share/nginx/html/assets/config.json.tmp
+    mv /usr/share/nginx/html/assets/config.json.tmp /usr/share/nginx/html/assets/config.json
+fi
+
+envsubst < /etc/nginx/conf.d/default.conf > /etc/nginx/conf.d/default.conf.tmp
+if [ "$FRAME_PROTECTION_ENABLED" = "false" ]; then
+   grep -v "Content-Security-Policy" /etc/nginx/conf.d/default.conf.tmp > /etc/nginx/conf.d/defaultWithoutProtection.conf.tmp
+   mv /etc/nginx/conf.d/defaultWithoutProtection.conf.tmp /etc/nginx/conf.d/default.conf.tmp
+fi
+mv /etc/nginx/conf.d/default.conf.tmp /etc/nginx/conf.d/default.conf
+
+# start nginx foreground
+exec /usr/sbin/nginx -g 'daemon off;'


### PR DESCRIPTION

Remove confd from our nginx images to fix security issues.
We are temporarily adding a new `nginx-confd` image to not break the actual APIM/AM images.
