### PR TITLE
feat(management-ui): enable ui-path configuration with MGMT_UI_PATH

### DIFF
--- a/images/management-ui/config/templates/default.conf.tmpl
+++ b/images/management-ui/config/templates/default.conf.tmpl
@@ -16,7 +16,7 @@ server {
     gzip_http_version 1.1;
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
     
-    location / {
+    location {{ getenv "MGMT_UI_PATH" "/" }} {
         try_files $uri $uri/ =404;
         root /var/www/html;
     }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/4550 seems related, https://github.com/gravitee-io/issues/issues/4781 too. I can open a specific issue if needed. 

**Description**

This enables the configuration of the served URL when an ingress can't rewrite URLs. 

In our case we have developer.example.org/ui/ serving for developer.example.org/management backend. When migrating to AWS with https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.5/ it's not possible to rewrite (such as  https://kubernetes.github.io/ingress-nginx/examples/rewrite/) 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
