### PR TITLE
fix: remove host volume in apim 4x docker compose

### DIFF
--- a/apim/4.x/docker-compose.yml
+++ b/apim/4.x/docker-compose.yml
@@ -32,7 +32,6 @@ services:
     restart: always
     volumes:
       - data-mongo:/data/db
-      - ./logs/apim-mongodb:/var/log/mongodb
     networks:
       - storage
 
@@ -67,8 +66,6 @@ services:
     depends_on:
       - mongodb
       - elasticsearch
-    volumes:
-      - ./logs/apim-gateway:/opt/graviteeio-gateway/logs
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
@@ -89,8 +86,6 @@ services:
     depends_on:
       - mongodb
       - elasticsearch
-    volumes:
-      - ./logs/apim-management-api:/opt/graviteeio-management-api/logs
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
@@ -108,8 +103,6 @@ services:
       - management_api
     environment:
       - MGMT_API_URL=http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT/
-    volumes:
-      - ./logs/apim-management-ui:/var/log/nginx
     networks:
       - frontend
 
@@ -123,7 +116,5 @@ services:
       - management_api
     environment:
       - PORTAL_API_URL=http://localhost:8083/portal/environments/DEFAULT
-    volumes:
-      - ./logs/apim-portal-ui:/var/log/nginx
     networks:
       - frontend


### PR DESCRIPTION
**Issue**

DV-339
DV-347

**Description**

As seen [here](https://community.gravitee.io/t/i-installed-latest-docker-compose-and-installation-guaid-for-graviteeio-and-got-failer-error-for-api-gateway-run/2253/7) and [here](https://community.gravitee.io/t/docker-compose-deployment-failure/2242/6) the usage of host volume can generate some permission issue.

Also each container don't use the same user id:

```bash
➜  ~ docker run --rm -ti --entrypoint /bin/sh graviteeio/apim-management-api:4 -c id
uid=1001(graviteeio) gid=1000(graviteeio) groups=1000(graviteeio)
➜  ~ docker run --rm -ti --entrypoint /bin/sh graviteeio/apim-management-ui:4 -c id
uid=101(nginx) gid=101(nginx) groups=101(nginx)
```

It's means that on the host (which in linux probably have a user id to 1000) using these logs files is not as easy as it could be.

Finally, we do not need these logs files as we can already see the logs from docker output like:

```bash
docker compose logs management_api
```

or at least inside the container itself.

So the proposal here is to simply remove these volumes.