### PR TITLE
chore: upgrade alpine version to 3.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,14 +41,29 @@ commands:
 jobs:
   build-and-push-java:
     executor: docker/docker
+    parameters:
+      alpine_version:
+        type: string
+        default: ""
     steps:
       - checkout
       - prepare-docker-context
-      - run:
-          command: |
-            docker context create tls-env
-            docker buildx create tls-env --use
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -t graviteeio/java:17 -f images/java/Dockerfile images/java/
+      - when :
+          condition: << parameters.alpine_version >>
+          steps:
+            - run:
+                command: |
+                  docker context create tls-env
+                  docker buildx create tls-env --use
+                  docker buildx build --push --platform=linux/arm64,linux/amd64 --build-arg ALPINE_VERSION=<< parameters.alpine_version >> -t graviteeio/java:17-alpine-<< parameters.alpine_version >> -f images/java/Dockerfile images/java/
+      - unless:
+          condition: << parameters.alpine_version >>
+          steps:
+            - run:
+                command: |
+                  docker context create tls-env
+                  docker buildx create tls-env --use
+                  docker buildx build --push --platform=linux/arm64,linux/amd64 -t graviteeio/java:17 -f images/java/Dockerfile images/java/
 
   build-and-push-java21:
     executor: docker/docker
@@ -132,6 +147,9 @@ workflows:
     jobs:
       - build-and-push-java:
           context: cicd-orchestrator
+      - build-and-push-java:
+          context: cicd-orchestrator
+          alpine_version: "3.20"
       - add-docker-images-in-snyk:
           context: cicd-orchestrator
           requires:

--- a/images/java/Dockerfile
+++ b/images/java/Dockerfile
@@ -10,10 +10,11 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM alpine:3.17
+ARG ALPINE_VERSION=3.17
+FROM alpine:${ALPINE_VERSION}
 
-ENV JAVA_HOME /opt/java/openjdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
**Issue**

N/A

**Description**

Due a known issue about DNS resolution, https://bell-sw.com/blog/how-to-deal-with-alpine-dns-issues, we should upgrade the alpine version we use for our java image.

This PR upgrades alpine from 3.17 to 3.20.
Here are the release notes:
 - https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.18.0
 - https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.19.0
 - https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.20.0

I think that the only notable thing is the removal of libc6-compat in. 3.19
![image](https://github.com/user-attachments/assets/1a1c37b3-c636-4674-8af5-17fc4e8cee60)

But I may have missed something else.

⚠️ Do not merge this PR until we are sure it will not override the existing tag⚠️
