### PR TITLE
feat(nginx): add support for IPV4_ONLY configuration to exclude IPv6 features

### DIFF
--- a/images/nginx/run.sh
+++ b/images/nginx/run.sh
@@ -37,6 +37,10 @@ if [ "$FRAME_PROTECTION_ENABLED" = "false" ]; then
    grep -v "Content-Security-Policy" /rw.mount/nginx/default.conf.tmp > /rw.mount/nginx/defaultWithoutProtection.conf.tmp
    mv /rw.mount/nginx/defaultWithoutProtection.conf.tmp /rw.mount/nginx/default.conf.tmp
 fi
+if [ "$IPV4_ONLY" = "true" ]; then
+   grep -v "# feature-ipv6" /rw.mount/nginx/default.conf.tmp > /rw.mount/nginx/defaultWithoutIPv6.conf.tmp
+   mv /rw.mount/nginx/defaultWithoutIPv6.conf.tmp /rw.mount/nginx/default.conf.tmp
+fi
 mv /rw.mount/nginx/default.conf.tmp /rw.mount/nginx/default.conf
 
 # start nginx foreground


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8572

**Description**

Add IPV4_ONLY for hosts with docker ipv6 feature disabled

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
