### PR TITLE
Update docker-compose.yml

### DIFF
--- a/apim/4.x/docker-compose.yml
+++ b/apim/4.x/docker-compose.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: '3.5'
 
 networks:
   frontend:


### PR DESCRIPTION
The version attribute has been deprecated as of 2021. Removing to reduce warnings during docker compose up.

**Issue**
Cleanup chore.

**Description**

Removed version attribute from docker compose in order to reduce warnings. The attribute has been deprecated as of 2021.

**Additional context**
