### PR TITLE
fix(java-17): upgrade to jre/jdk 17.0.15

### DIFF
--- a/images/java/Dockerfile
+++ b/images/java/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
   ARCH="$(apk --print-arch)"; \
   case "${ARCH}" in \
     amd64|x86_64) \
-      ESUM='7a2df4e2f86eca649af1e17d990ab8e354cb6dee389606025b9d05f75623c388'; \
+      ESUM='38c90337ca2471085f9292d24bec75413b4e56c7826ef25e150a40cc2f727e36'; \
       BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.15%2B6/OpenJDK17U-jre_x64_alpine-linux_hotspot_17.0.15_6.tar.gz' \
     ;; \
     aarch64) \


### PR DESCRIPTION
**Issue**

We forgot to update the ESUM to the last PR https://github.com/gravitee-io/gravitee-docker/pull/213

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
