### PR TITLE
feat(images): add new java image based on Debian stable-slim with Java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
       - docker/check
 
 jobs:
-  build-and-push-java:
+  build-and-push-java-legacy:
     executor: docker/docker
     parameters:
       alpine_version:
@@ -31,29 +31,116 @@ jobs:
           condition: << parameters.alpine_version >>
           steps:
             - run:
+                name: Build Legacy Java alpine version << parameters.alpine_version >>
                 command: |
                   docker context create tls-env
                   docker buildx create tls-env --use
-                  docker buildx build --push --platform=linux/arm64,linux/amd64 --build-arg ALPINE_VERSION=<< parameters.alpine_version >> -t graviteeio/java:17-alpine-<< parameters.alpine_version >> -f images/java/Dockerfile images/java/
+                  docker buildx build \
+                    --push \
+                    --platform=linux/arm64,linux/amd64 \
+                    --build-arg ALPINE_VERSION=<< parameters.alpine_version >> \
+                    -t graviteeio/java:17-alpine-<< parameters.alpine_version >> \
+                    -f images/java/Dockerfile.legacy \
+                    images/java/
       - unless:
           condition: << parameters.alpine_version >>
           steps:
             - run:
+                name: Build Legacy Java alpine version 17
                 command: |
                   docker context create tls-env
                   docker buildx create tls-env --use
-                  docker buildx build --push --platform=linux/arm64,linux/amd64 -t graviteeio/java:17 -f images/java/Dockerfile images/java/
+                  docker buildx build \
+                    --push \
+                    --platform=linux/arm64,linux/amd64 \
+                    -t graviteeio/java:17 \
+                    -f images/java/Dockerfile.legacy \
+                    images/java/
 
-  build-and-push-java21:
+  build-and-push-java:
     executor: docker/docker
+    parameters:
+      dry_run:
+        description: "if true, do not push docker image"
+        type: string
+        default: "false"
+      variant_name:
+        description: "docker image variant name that will be publish"
+        type: string
+        default: ""
+      base_image_version:
+        description: "the base image variant to use from"
+        type: string
+        default: ""
+      java_version:
+        description: "java variant to use (from temurin package in debian and eclipse-temurin variant for alpine)"
+        type: string
+        default: ""
+      graviteeio_user:
+        description: "for alpine based image, set it to graviteeio and keep it empty for backward compatibility with default image"
+        type: string
+        default: ""
     steps:
       - checkout
       - prepare-docker-context
-      - run:
-          command: |
-            docker context create tls-env
-            docker buildx create tls-env --use
-            docker buildx build --push --platform=linux/arm64,linux/amd64 -t graviteeio/java:21 -f images/java21/Dockerfile images/java21/
+      - when:
+          condition:
+            or:
+              - matches: { pattern: "^.*-alpine$", value: << parameters.variant_name >> }
+                # our default java version (without specify variant == alpine)
+              - matches: { pattern: "^[0-9.]+$", value: << parameters.variant_name >> }
+          steps:
+            - run:
+                name: Build Java Alpine variant << parameters.variant_name >>
+                command: |
+                  docker context create tls-env
+                  docker buildx create tls-env --use
+                  
+                  dockerArgs="--push --platform=linux/arm64,linux/amd64"
+                  if [[ "<< parameters.dry_run >>" == "true" ]]
+                  then
+                    dockerArgs="--output=type=docker,context=tls-env"
+                  fi
+                  
+                  docker buildx build \
+                    ${dockerArgs} \
+                    --build-arg JAVA_VERSION=<< parameters.java_version >> \
+                    --build-arg GRAVITEEIO_USER=<< parameters.graviteeio_user >> \
+                    -t graviteeio/java:<< parameters.variant_name >> \
+                    -f images/java/Dockerfile.alpine \
+                    images/java/
+                  
+                  docker run --rm -ti \
+                    graviteeio/java:<< parameters.variant_name >> \
+                    /bin/sh -c "id && java --version"
+      - when:
+          condition:
+            matches: { pattern: "^.*-debian$", value: << parameters.variant_name >> }
+          steps:
+            - run:
+                name: Build Java Debian variant << parameters.variant_name >>
+                command: |
+                  docker context create tls-env
+                  docker buildx create tls-env --use
+                  pushCommand="--push"
+                  
+                  dockerArgs="--push --platform=linux/arm64,linux/amd64"
+                  if [[ "<< parameters.dry_run >>" == "true" ]]
+                  then
+                    dockerArgs="--output=type=docker,context=tls-env"
+                  fi
+                  
+                  docker buildx build \
+                    ${dockerArgs} \
+                    --build-arg DEBIAN_VERSION=<< parameters.base_image_version >> \
+                    --build-arg JAVA_VERSION=<< parameters.java_version >> \
+                    -t graviteeio/java:<< parameters.variant_name >> \
+                    -f images/java/Dockerfile.debian \
+                    images/java/
+                  
+                  docker run --rm -ti \
+                    graviteeio/java:<< parameters.variant_name >> \
+                    /bin/sh -c "id && java --version"
 
   build-and-push-nginx:
     executor: docker/docker
@@ -180,7 +267,7 @@ workflows:
       and:
         - equal: [ master, << pipeline.git.branch >> ]
     jobs:
-      - build-and-push-java:
+      - build-and-push-java-legacy:
           name: build java with alpine 3.20
           context: cicd-orchestrator
           alpine_version: "3.20"
@@ -190,7 +277,7 @@ workflows:
             - build java with alpine 3.20
           docker-image-name: java
           version: "17-alpine-3.20"
-      - build-and-push-java:
+      - build-and-push-java-legacy:
           name: build java with alpine 3.21
           context: cicd-orchestrator
           alpine_version: "3.21"
@@ -200,14 +287,51 @@ workflows:
             - build java with alpine 3.21
           docker-image-name: java
           version: "17-alpine-3.21"
-      - build-and-push-java21:
+      - build-and-push-java-legacy:
+          name: build java with alpine 3.22
           context: cicd-orchestrator
+          alpine_version: "3.22"
       - add-docker-images-in-aqua:
           context: cicd-orchestrator
           requires:
-            - build-and-push-java21
+            - build java with alpine 3.22
+          docker-image-name: java
+          version: "17-alpine-3.22"
+      - build-and-push-java:
+          name: build our default java based image (eclipse-temurin:21-jre-alpine)
+          context: cicd-orchestrator
+          variant_name: "21"
+          java_version: "21-jre"
+      - add-docker-images-in-aqua:
+          context: cicd-orchestrator
+          requires:
+            - build our default java based image (eclipse-temurin:21-jre-alpine)
           docker-image-name: java
           version: "21"
+      - build-and-push-java:
+          name: build java based on alpine with java 21-jre
+          context: cicd-orchestrator
+          variant_name: "21-alpine"
+          java_version: "21-jre"
+          graviteeio_user: "graviteeio"
+      - add-docker-images-in-aqua:
+          context: cicd-orchestrator
+          requires:
+            - build java based on alpine with java 21-jre
+          docker-image-name: java
+          version: "21-alpine"
+      - build-and-push-java:
+          name: build java based on debian stable-slim and java 21-jre
+          context: cicd-orchestrator
+          variant_name: "21-debian"
+          base_image_version: "stable-slim"
+          java_version: "21-jre"
+      - add-docker-images-in-aqua:
+          context: cicd-orchestrator
+          requires:
+            - build java based on debian stable-slim and java 21-jre
+          docker-image-name: java
+          version: "21-debian"
       - build-and-push-nginx:
           name: build nginx 1.26.3
           context: cicd-orchestrator

--- a/images/java/Dockerfile.alpine
+++ b/images/java/Dockerfile.alpine
@@ -10,7 +10,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-FROM eclipse-temurin:21-jre-alpine
+ARG JAVA_VERSION
+FROM eclipse-temurin:${JAVA_VERSION:-21-jre}-alpine
+LABEL maintainer="contact@graviteesource.com"
 
 # Default to UTF-8 file.encoding
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -24,5 +26,12 @@ RUN echo Verifying install ... \
   && echo java --version && java --version \
   && echo Complete.
 
+ARG GRAVITEEIO_USER
+RUN if [[ -n "${GRAVITEEIO_USER}" ]]; then \
+        addgroup -g 1000 graviteeio ;\
+        adduser -D -H -u 1001 graviteeio --ingroup graviteeio ;\
+    fi
+
+USER ${GRAVITEEIO_USER:-root}
 # Define default command.
 CMD ["java", "-version"]

--- a/images/java/Dockerfile.debian
+++ b/images/java/Dockerfile.debian
@@ -1,0 +1,49 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2015-2022 The Gravitee team (http://gravitee.io)
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#            http://www.apache.org/licenses/LICENSE-2.0
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#-------------------------------------------------------------------------------
+ARG DEBIAN_VERSION
+FROM debian:${DEBIAN_VERSION:-stable-slim}
+LABEL maintainer="contact@graviteesource.com"
+
+# Default to UTF-8 file.encoding
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+ARG JAVA_VERSION
+ENV JAVA_VERSION=${JAVA_VERSION:-21-jre}
+
+RUN set -eux ;\
+    DEBIAN_FRONTEND=noninteractive ;\
+    apt-get update ;\
+    apt-get upgrade --yes ;\
+    apt-get install --yes locales apt-transport-https curl gpg zip ;\
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen ;\
+    locale-gen en_US.UTF-8 ;\
+    curl -q https://packages.adoptium.net/artifactory/api/gpg/key/public \
+        | gpg --dearmor \
+        | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null ;\
+    echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
+        | tee /etc/apt/sources.list.d/adoptium.list ;\
+    apt-get update ;\
+    apt-get install --yes "temurin-${JAVA_VERSION}" ;\
+    apt-get clean ;\
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "Verifying install with: java --version" ;\
+    java --version ;\
+    echo "Complete."
+
+RUN addgroup --gid 1000 graviteeio \
+	&& adduser --home /home/graviteeio --uid 1001 --gid 1000 --disabled-password graviteeio
+ENV HOME=/home/graviteeio
+
+USER graviteeio
+CMD ["java", "-version"]

--- a/images/java/Dockerfile.legacy
+++ b/images/java/Dockerfile.legacy
@@ -10,8 +10,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-ARG ALPINE_VERSION=3.20
-FROM alpine:${ALPINE_VERSION}
+ARG ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION:-3.22}
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH=$JAVA_HOME/bin:$PATH


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/TT-7762

**Description**

Add new Java image based on Debian.

* java Dockerfiles
  * create new java `Dockerfile.debian`
  * remove `java21` folder and move `Dockerfile` in `Dockerfile.alpine`
  * move `image/java/Dockerfile` to `image/java/Dockerfile.legacy`
  * for each variante create `graviteeio` user
  * introduce backward compatibility without `graviteeio` user on alpine
* CI
  * update java build to handle variante, default and legacy
  * rename `build-and-push-java` to `build-and-push-java-legacy`
  * refactor `build-and-push-java21` to `build-and-push-java`
    * it manage default java image : java:21 == java:21-alpine
    * the debian and alpine variant
  * update `run_every_week` workflow to match changes above.

