### PR TITLE
fix(nginx): re add curl command in nginx base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,6 @@ jobs:
                 command: |
                   docker context create tls-env
                   docker buildx create tls-env --use
-                  pushCommand="--push"
                   
                   dockerArgs="--push --platform=linux/arm64,linux/amd64"
                   if [[ "<< parameters.dry_run >>" == "true" ]]

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -19,6 +19,10 @@ ENV HTTP_PORT=8080
 ENV HTTPS_PORT=8443
 ENV SERVER_NAME=_
 
+RUN apk -U upgrade \
+  && apk add --no-cache curl \
+  && rm -rf /var/cache/apk/*
+
 ADD nginx.conf /etc/nginx
 
 RUN mkdir -p /rw.mount/nginx/logs; \


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/TT-7811

**Description**

We recently change the base image of our graviteeio/nginx:1.27.5 from nginx:1.27.5-alpine to nginx:1.27.5-alpine-slimto reduce the number of library and related vulnerability exposure.

As a consequences, the curl command is not in the image anymore.

The only identified impact for the moment are in docker-compose usage where curl is used for healthcheck.

To prevent this and any other issue, we need to re-integrate curl in the base image.

