### PR TITLE
security(nginx): update NGINX_VERSION to 1.30.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,6 +425,19 @@ workflows:
             - build nginx 1.27.5
           docker-image-name: nginx
           version: "1.27.5"
+      - &build-nginx-1230
+        build-and-push-nginx:
+          name: build nginx 1.30.0
+          context: cicd-orchestrator
+          version: "1.30.0"
+      - &aqua-nginx-1230
+        add-docker-images-in-aqua:
+          name: analyze nginx 1.30.0
+          context: cicd-orchestrator
+          requires:
+            - build nginx 1.30.0
+          docker-image-name: nginx
+          version: "1.30.0"
       # Other images
       - build-and-push-git-http-server:
           name: build git-http-server
@@ -480,3 +493,5 @@ workflows:
       - *aqua-nginx-129
       - *build-nginx-1275
       - *aqua-nginx-1275
+      - *build-nginx-1230
+      - *aqua-nginx-1230

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-ARG  NGINX_VERSION=1.25
+ARG  NGINX_VERSION=1.30.0
 FROM nginx:${NGINX_VERSION}-alpine-slim
 LABEL maintainer="contact@graviteesource.com"
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-13245

**Description**

This fix aims to remove the vulnerability **CVE 2026 1642** from the docker image. 


**Additional context**

Pre fix scan: 

<img width="3024" height="372" alt="image" src="https://github.com/user-attachments/assets/539ba238-f884-4f4d-bf7f-7817fdd24739" />


Post fix scan: 

<img width="1764" height="546" alt="image" src="https://github.com/user-attachments/assets/5fb16a0b-17c4-4f06-8b17-1e171f2f4224" />
