### PR TITLE
fix(java-alpine): create graviteeio home directory

### DIFF
--- a/images/java/Dockerfile.alpine
+++ b/images/java/Dockerfile.alpine
@@ -29,7 +29,7 @@ RUN echo Verifying install ... \
 ARG GRAVITEEIO_USER
 RUN if [[ -n "${GRAVITEEIO_USER}" ]]; then \
         addgroup -g 1000 graviteeio ;\
-        adduser -D -H -u 1001 graviteeio --ingroup graviteeio ;\
+        adduser -D -h /home/graviteeio -u 1001 graviteeio --ingroup graviteeio ;\
     fi
 
 USER ${GRAVITEEIO_USER:-root}


### PR DESCRIPTION
**Issue**

- https://graviteesource.zendesk.com/agent/tickets/16640
- https://gravitee.atlassian.net/browse/CJ-4581

**Description**

The new `gravitee-policy-js` plugin bundles GraalVM/Truffle, which writes a cache under `${user.home}/.cache/...` on first init. On the Alpine gateway image, the `graviteeio` user is configured with `/home/graviteeio` as `$HOME` but the directory was never created on disk (`adduser -D -H` skips home directory creation), so the cache write fails and the policy can never initialise. The customer sees a 504 and `NoClassDefFoundError: ...Engine$ImplHolder` in the logs.

This affects every hybrid customer running the JS policy on the default Alpine image. NextGen SaaS is unaffected because it runs the Debian variant, which creates the home directory correctly.

**Fix**

Replace `-H` with `-h /home/graviteeio` so the home directory is created and owned by the user, matching `Dockerfile.debian`.

Verified locally by reproducing the customer's 504 against `apim-gateway:4.11.6`, rebuilding the gateway on top of a patched base image, and re-running through the full APIM stack — the 504 becomes a 200 and the JS policy executes cleanly.

**Customer workaround until this propagates**

Switch the gateway image tag from `X.Y.Z` to `X.Y.Z-debian`.

**Related**

A docs PR on the JS policy adds a temporary known-issue note pointing at the same workaround: https://github.com/gravitee-io/gravitee-policy-js/pull/47

---
_PR created with Claude Code._