### PR TITLE
security(nginx): update NGINX_VERSION to 1.30.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ workflows:
         build-and-push-nginx:
           name: build nginx 1.30
           context: cicd-orchestrator
-          version: "1.30"
+          version: "1.30.2"
       - &aqua-nginx-130
         add-docker-images-in-aqua:
           name: analyze nginx 1.30
@@ -437,20 +437,7 @@ workflows:
           requires:
             - build nginx 1.30
           docker-image-name: nginx
-          version: "1.30"
-      - &build-nginx-132
-        build-and-push-nginx:
-          name: build nginx 1.32
-          context: cicd-orchestrator
-          version: "1.32"
-      - &aqua-nginx-132
-        add-docker-images-in-aqua:
-          name: analyze nginx 1.32
-          context: cicd-orchestrator
-          requires:
-            - build nginx 1.32
-          docker-image-name: nginx
-          version: "1.32"
+          version: "1.30.2"
       # Other images
       - build-and-push-git-http-server:
           name: build git-http-server
@@ -508,5 +495,3 @@ workflows:
       - *aqua-nginx-1275
       - *build-nginx-130
       - *aqua-nginx-130
-      - *build-nginx-132
-      - *aqua-nginx-132


### PR DESCRIPTION

## Issue

https://github.com/gravitee-io/issues/issues/APIM-14227

## Description

Adding a security patch for https://github.com/advisories/GHSA-h78r-86c6-jgp4

## Additional context

Adding a security patch for CVE-2026-9256
Fixed failing version on master 1.32 --> 1.30.2
Removed additional config for minor version change
