### PR TITLE
Revert "security(nginx): update NGINX_VERSION to 1.30.2"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,19 +438,6 @@ workflows:
             - build nginx 1.30
           docker-image-name: nginx
           version: "1.30"
-      - &build-nginx-132
-        build-and-push-nginx:
-          name: build nginx 1.32
-          context: cicd-orchestrator
-          version: "1.32"
-      - &aqua-nginx-132
-        add-docker-images-in-aqua:
-          name: analyze nginx 1.32
-          context: cicd-orchestrator
-          requires:
-            - build nginx 1.32
-          docker-image-name: nginx
-          version: "1.32"
       # Other images
       - build-and-push-git-http-server:
           name: build git-http-server
@@ -508,5 +495,3 @@ workflows:
       - *aqua-nginx-1275
       - *build-nginx-130
       - *aqua-nginx-130
-      - *build-nginx-132
-      - *aqua-nginx-132

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ workflows:
         build-and-push-nginx:
           name: build nginx 1.30
           context: cicd-orchestrator
-          version: "1.30.2"
+          version: "1.30"
       - &aqua-nginx-130
         add-docker-images-in-aqua:
           name: analyze nginx 1.30
@@ -437,7 +437,20 @@ workflows:
           requires:
             - build nginx 1.30
           docker-image-name: nginx
-          version: "1.30.2"
+          version: "1.30"
+      - &build-nginx-132
+        build-and-push-nginx:
+          name: build nginx 1.32
+          context: cicd-orchestrator
+          version: "1.32"
+      - &aqua-nginx-132
+        add-docker-images-in-aqua:
+          name: analyze nginx 1.32
+          context: cicd-orchestrator
+          requires:
+            - build nginx 1.32
+          docker-image-name: nginx
+          version: "1.32"
       # Other images
       - build-and-push-git-http-server:
           name: build git-http-server
@@ -495,3 +508,5 @@ workflows:
       - *aqua-nginx-1275
       - *build-nginx-130
       - *aqua-nginx-130
+      - *build-nginx-132
+      - *aqua-nginx-132

--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -10,7 +10,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #-------------------------------------------------------------------------------
-ARG  NGINX_VERSION=1.30.2
+ARG  NGINX_VERSION=1.30
 FROM nginx:${NGINX_VERSION}-alpine-slim
 LABEL maintainer="contact@graviteesource.com"
 
@@ -32,7 +32,5 @@ RUN mkdir -p /rw.mount/nginx/logs; \
   chmod -R g+w /var/cache/nginx /rw.mount
 
 COPY run.sh /run.sh
-
-USER nginx
 
 CMD ["sh", "/run.sh"]


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

This reverts commits https://github.com/gravitee-io/gravitee-docker/commit/63d902a4fed10333160a649ef844375770578a4d and https://github.com/gravitee-io/gravitee-docker/commit/7558daf91cafb304a7fc3de8b531796d45a0d4bc
